### PR TITLE
Update nextTick() to execute after immediate and timer

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -176,7 +176,7 @@ export function defer<T>(): Deferred<T> {
 }
 
 export function nextTick(): Promise<void> {
-    return new Promise(resolve => setImmediate(resolve));
+    return new Promise(resolve => setTimeout(() => setImmediate(resolve), 0));
 }
 
 // Export default object with all members (ember-browserify doesn't support named exports).

--- a/test/nextTick.spec.ts
+++ b/test/nextTick.spec.ts
@@ -1,0 +1,30 @@
+import {nextTick} from "../src/ts-mockito";
+
+describe("nextTick", () => {
+    it('should execute after setImmediate()', async () => {
+        let done = false;
+
+        setImmediate(() => done = true);
+
+        await nextTick();
+        expect(done).toBe(true);
+    });
+
+    it('should execute after setTimeout(0)', async () => {
+        let done = false;
+
+        setTimeout(() => done = true, 0);
+
+        await nextTick();
+        expect(done).toBe(true);
+    });
+
+    it('should execute after promise', async () => {
+        let done = false;
+
+        Promise.resolve().then(() => done = true);
+
+        await nextTick();
+        expect(done).toBe(true);
+    });
+});


### PR DESCRIPTION
Use `await nextTick()` to await any promise or async operation to complete