### PR TITLE
Disallow thenReturn() without arguments unless the return type is void

### DIFF
--- a/src/MethodStubSetter.ts
+++ b/src/MethodStubSetter.ts
@@ -6,17 +6,30 @@ import {ReturnValueMethodStub} from "./stub/ReturnValueMethodStub";
 import {ThrowErrorMethodStub} from "./stub/ThrowErrorMethodStub";
 
 export interface SyncMethodStubSetter<T> {
-    thenReturn(...rest: T[]): this;
-    thenThrow(...rest: Error[]): this;
+    thenReturn(head: T, ...tail: T[]): this;
+    thenThrow(head: Error, ...tail: Error[]): this;
     thenCall(func: (...args: any[]) => T): this;
 }
 
-export interface AsyncMethodStubSetter<T, ResolveType> extends SyncMethodStubSetter<T> {
-    thenResolve(...rest: ResolveType[]): this;
-    thenReject(...rest: any[]): this;
+export interface VoidSyncMethodStubSetter<T> {
+  thenReturn(head: T, ...tail: T[]): this;
+  thenReturn(): this;
+  thenThrow(head: Error, ...tail: Error[]): this;
+  thenCall(func: (...args: any[]) => T): this;
 }
 
-export class MethodStubSetter<T, ResolveType> implements AsyncMethodStubSetter<T, ResolveType> {
+export interface AsyncMethodStubSetter<T, ResolveType> extends SyncMethodStubSetter<T> {
+    thenResolve(head: ResolveType, ...tail: ResolveType[]): this;
+    thenReject(head: any, ...tail: any[]): this;
+}
+
+export interface VoidAsyncMethodStubSetter<T, ResolveType> extends VoidSyncMethodStubSetter<T> {
+  thenResolve(head: ResolveType, ...tail: ResolveType[]): this;
+  thenResolve(): this;
+  thenReject(head: any, ...tail: any[]): this;
+}
+
+export class MethodStubSetter<T, ResolveType> implements AsyncMethodStubSetter<T, ResolveType>, VoidAsyncMethodStubSetter<T, ResolveType> {
     private static globalGroupIndex: number = 0;
     private groupIndex: number;
 
@@ -26,6 +39,10 @@ export class MethodStubSetter<T, ResolveType> implements AsyncMethodStubSetter<T
     }
 
     public thenReturn(...rest: T[]): this {
+        // Returns undefined if no return values are given.
+        if (rest.length === 0) {
+          rest.push(undefined);
+        }
         rest.forEach(value => {
             this.methodToStub.methodStubCollection.add(new ReturnValueMethodStub(this.groupIndex, this.methodToStub.matchers, value));
         });

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -33,7 +33,7 @@ import {LowerThanOrEqualMatcher} from "./matcher/type/number/LowerThanOrEqualMat
 import {ObjectContainingMatcher} from "./matcher/type/ObjectContainingMatcher";
 import {StartsWithMatcher} from "./matcher/type/StartsWithMatcher";
 import {StrictEqualMatcher} from "./matcher/type/StrictEqualMatcher";
-import {AsyncMethodStubSetter,MethodStubSetter,SyncMethodStubSetter} from "./MethodStubSetter";
+import {AsyncMethodStubSetter,VoidAsyncMethodStubSetter,MethodStubSetter,SyncMethodStubSetter,VoidSyncMethodStubSetter} from "./MethodStubSetter";
 import {MethodStubVerificator} from "./MethodStubVerificator";
 import {MethodToStub} from "./MethodToStub";
 import {Mocker, MockPropertyPolicy} from "./Mock";
@@ -84,8 +84,10 @@ export function verify<T>(method: T): MethodStubVerificator<T> {
     return new MethodStubVerificator(method as any);
 }
 
+export function when<T>(method: PromiseLike<void>): VoidAsyncMethodStubSetter<PromiseLike<T>, T>;
 export function when<T>(method: PromiseLike<T>): AsyncMethodStubSetter<PromiseLike<T>, T>;
 export function when<T>(method: Promise<T>): AsyncMethodStubSetter<Promise<T>, T>;
+export function when<T>(method: void): VoidSyncMethodStubSetter<T>;
 // When T is any - return AsyncMethodStubSetter<any, any>, otherwise return SynccMethodStubSetter<T>
 export function when<T>(method: T): 0 extends (1 & T) ? AsyncMethodStubSetter<any, any> : SyncMethodStubSetter<T>;
 export function when<T>(method: any): any {

--- a/test/recording.multiple.behaviors.spec.ts
+++ b/test/recording.multiple.behaviors.spec.ts
@@ -103,6 +103,22 @@ describe("recording multiple behaviors", () => {
         });
     });
 
+    it("should allow thenReturn without value for void return type", () => {
+        // given
+        when(mockedFoo.methodReturningVoid()).thenReturn();
+
+        // when
+        const value = foo.methodReturningVoid();
+
+        // then
+        expect(value).toBe(undefined);
+    });
+
+    // Should not compile
+    // it("should not allow thenReturn without value for non void return type", () => {
+    //   when(mockedFoo.getBar()).thenReturn();
+    // });
+
     describe("when return values are mixed with throw errors", () => {
         it("uses one by one and repeat last one infinitely", () => {
             // given

--- a/test/stubbing.method.spec.ts
+++ b/test/stubbing.method.spec.ts
@@ -229,6 +229,11 @@ describe("mocking", () => {
                     .catch(err => done.fail(err));
             });
 
+            // Should not compile
+            // it("should not allow thenResolve without arguments if the return type is not Promise<void>", done => {
+            //     when(mockedFoo.sampleMethodReturningPromise("abc")).thenResolve();
+            // });
+            
             if (typeof Proxy !== "undefined") {
                 it("resolves with given mock value", done => {
                     // given
@@ -279,6 +284,68 @@ describe("mocking", () => {
                         done();
                     });
             });
+
+            it("rejects with given value for PromiseLike", done => {
+                // given
+                const sampleValue = "abc";
+                const sampleError = new Error("sampleError");
+                when(mockedFoo.sampleMethodReturningPromiseLike(sampleValue)).thenReject(sampleError);
+
+                // when
+                (foo.sampleMethodReturningPromiseLike(sampleValue) as Promise<string>)
+                    .then(value => done.fail("promise was not rejected"))
+                    .catch(err => {
+                        // then
+                        expect(err.message).toEqual("sampleError");
+                        done();
+                    });
+            });
+
+            it("rejects with multiple values", done => {
+                const sampleError1 = new Error("one");
+                const sampleError2 = new Error("two");
+                const sampleError3 = new Error("three");
+                when(mockedFoo.sampleMethodReturningPromise("abc")).thenReject(sampleError1, sampleError2, sampleError3);
+
+                foo.sampleMethodReturningPromise("abc")
+                    .then(value => done.fail("promise was not rejected"))
+                    .catch(err => {
+                        expect(err.message).toEqual("one");
+                        return foo.sampleMethodReturningPromise("abc");
+                    })
+                    .then(value => done.fail("promise was not rejected"))
+                    .catch(err => {
+                        expect(err.message).toEqual("two");
+                        return foo.sampleMethodReturningPromise("abc");
+                    })
+                    .then(value => done.fail("promise was not rejected"))
+                    .catch(err => {
+                        expect(err.message).toEqual("three");
+                        done();
+                    })
+            });
+
+            it("rejects void promise", done => {
+                const sampleError = new Error("sampleError");
+                when(mockedFoo.sampleMethodReturningVoidPromise("abc")).thenReject(sampleError);
+
+                foo.sampleMethodReturningVoidPromise("abc")
+                    .then(value => done.fail("promise was not rejected"))
+                    .catch(err => {
+                        expect(err.message).toEqual("sampleError");
+                        done();
+                    });
+            });
+
+            // Should not compile
+            // it("should not allow thenReject without arguments if the return type is Promise<void>", done => {
+            //     when(mockedFoo.sampleMethodReturningVoidPromise("abc")).thenReject();
+            // });
+
+            // Should not compile
+            // it("should not allow thenReject without arguments if the return type is not Promise<void>", done => {
+            //     when(mockedFoo.sampleMethodReturningPromise("abc")).thenReject();
+            /// });
         });
 
         describe("with stubbed function call", () => {

--- a/test/utils/Foo.ts
+++ b/test/utils/Foo.ts
@@ -11,6 +11,9 @@ export class Foo {
         return "bar";
     }
 
+    public methodReturningVoid(): void {
+    }
+
     public concatStringWithNumber(sampleString: string, sampleNumber: number): string {
         return sampleString + sampleNumber;
     }


### PR DESCRIPTION
## Description

Since `.thenReturn()` without arguments is a no-op, adjust the types to disallow it. This will avoid mistakes in tests.
As a special case, allow `.thenReturn()` without arguments when the return type is `void`, meaning the same thing as `.thenReturn(undefined as void)`.