### PR TITLE
setImmediate not available in all environments

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -42,7 +42,7 @@ import {Spy} from "./Spy";
 // Keep a reference to the original, in case it is replaced with fake timers
 // by some library like jest or lolex
 const originalSetTimeout = setTimeout;
-const originalSetImmediate = setImmediate;
+const originalSetImmediate = 'setImmediate' in globalThis ? setImmediate : setTimeout;
 
 export {MockPropertyPolicy} from "./Mock";
 


### PR DESCRIPTION
In the latest Angular CLI project scaffolding for tests, the tests are run in an environment that does not provide `setImmediate` so it becomes necessary to polyfill it for ts-mockito.

This PR falls back to `setTimeout` if `setImmediate` is not availble and keeps backwards compatibility with other environments that might use it.

Let me know what you think!